### PR TITLE
Add Supabase newsletter form and landing CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# jocelynek
+# Jocelyne K — Landing page
+
+Cette application Vite + React propose une landing page pour la boutique de lunettes de soleil Jocelyne K et un formulaire d'inscription à la newsletter connecté à Supabase.
+
+## Prérequis
+
+- Node.js 18+
+- Variables d'environnement :
+  - `VITE_SUPABASE_URL`
+  - `VITE_SUPABASE_ANON_KEY`
+
+## Démarrer le projet
+
+```bash
+npm install
+npm run dev
+```
+
+Le site est disponible sur [http://localhost:5173](http://localhost:5173).
+
+## Tests manuels & mocks
+
+Pour valider les scénarios de succès et d'échec du formulaire sans dépendre du réseau, vous pouvez utiliser le mock fourni :
+
+```ts
+import NewsletterForm from './components/NewsletterForm';
+import { createSupabaseNewsletterMock } from './lib/mocks/supabaseClientMock';
+
+const failingClient = createSupabaseNewsletterMock({
+  error: { message: 'Simulation de coupure réseau' },
+});
+
+<NewsletterForm client={failingClient} />;
+```
+
+Scénarios conseillés :
+
+1. **Validation client** — Soumettre sans remplir les champs, puis avec un e-mail invalide.
+2. **Succès** — Remplir tous les champs et vérifier le message de confirmation.
+3. **Erreur réseau** — Injecter le mock en erreur pour afficher le message d'échec et l'état réinitialisable.
+
+## Production
+
+Avant la mise en production, exécutez :
+
+```bash
+npm run build
+```
+
+Cela génère les fichiers optimisés dans `dist/`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,66 @@
+import NewsletterForm from './components/NewsletterForm';
+
+const App = () => {
+  return (
+    <div className="page">
+      <header className="hero">
+        <div className="hero__content">
+          <p className="hero__eyebrow">Jocelyne K — Lunettes de soleil d'exception</p>
+          <h1 className="hero__title">
+            Brillez tout l'été avec un regard protégé et des montures iconiques
+          </h1>
+          <p className="hero__subtitle">
+            Découvrez nos collections limitées inspirées de la Riviera et conçues en France avec des
+            matériaux écoresponsables. Livraison express, garantie anti-rayures, et un style inimitable
+            pour vos journées les plus lumineuses.
+          </p>
+          <a className="hero__cta" href="#newsletter">
+            Voir les nouveautés
+          </a>
+        </div>
+        <div className="hero__visual" aria-hidden>
+          <div className="hero__badge">UV 400</div>
+        </div>
+      </header>
+
+      <main>
+        <section id="newsletter" className="cta">
+          <div className="cta__content">
+            <h2 className="cta__title">Rejoignez le cercle lumineux Jocelyne K</h2>
+            <p className="cta__description">
+              Chaque jeudi, recevez des lancements exclusifs, des conseils d'entretien et des invitations
+              VIP à nos pop-up stores. Vos informations sont stockées sur une infrastructure Supabase
+              sécurisée, hébergée dans l'Union européenne et pleinement conforme au RGPD.
+            </p>
+            <NewsletterForm />
+            <p className="cta__security">
+              <strong>Confidentialité garantie :</strong> nous chiffrons chaque contact, ne partageons jamais
+              vos données et vous pouvez vous désinscrire en un clic.
+            </p>
+          </div>
+        </section>
+      </main>
+
+      <footer className="footer">
+        <div className="footer__content">
+          <h2 className="footer__title">Jocelyne K</h2>
+          <p className="footer__text">
+            Boutique parisienne de lunettes de soleil premium depuis 2009. Certifiées UV 400,
+            garanties 3 ans et polarisées pour un confort optimal.
+          </p>
+          <div className="footer__security">
+            <h3 className="footer__security-title">Sécurité &amp; conformité</h3>
+            <ul className="footer__security-list">
+              <li>Hébergement Supabase avec sauvegardes quotidiennes.</li>
+              <li>Accès limité aux conseillers certifiés RGPD.</li>
+              <li>Suppression automatique des données sur simple demande.</li>
+            </ul>
+          </div>
+          <p className="footer__legal">© {new Date().getFullYear()} Jocelyne K. Tous droits réservés.</p>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -1,0 +1,260 @@
+import { type ChangeEvent, type FormEventHandler, useMemo, useState } from 'react';
+import type { PostgrestError } from '@supabase/supabase-js';
+
+import { supabase } from '../lib/supabaseClient';
+
+type NewsletterFormData = {
+  email: string;
+  firstName: string;
+  consent: boolean;
+};
+
+type FormErrors = Partial<Record<keyof NewsletterFormData, string>>;
+
+type NewsletterInsertPayload = {
+  email: string;
+  first_name: string;
+  consent: boolean;
+  subscribed_at: string;
+};
+
+type NewsletterClient = {
+  insert: (values: NewsletterInsertPayload) => Promise<{ error: PostgrestError | null }>;
+};
+
+type FormStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type NewsletterFormProps = {
+  client?: NewsletterClient;
+};
+
+const initialData: NewsletterFormData = {
+  email: '',
+  firstName: '',
+  consent: false,
+};
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/i;
+
+const defaultClient: NewsletterClient = {
+  insert: async (values) => {
+    const { error } = await supabase.from('newsletter').insert(values);
+    return { error };
+  },
+};
+
+const NewsletterForm = ({ client = defaultClient }: NewsletterFormProps) => {
+  const [formData, setFormData] = useState<NewsletterFormData>(initialData);
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const [status, setStatus] = useState<FormStatus>('idle');
+  const [submissionError, setSubmissionError] = useState<string | null>(null);
+
+  const isLoading = status === 'loading';
+
+  const resetForm = () => {
+    setFormData(initialData);
+    setFormErrors({});
+    setSubmissionError(null);
+    setStatus('idle');
+  };
+
+  const validate = (): FormErrors => {
+    const errors: FormErrors = {};
+    const trimmedEmail = formData.email.trim();
+    const trimmedFirstName = formData.firstName.trim();
+
+    if (!trimmedEmail) {
+      errors.email = "L'adresse e-mail est requise.";
+    } else if (!emailRegex.test(trimmedEmail)) {
+      errors.email = "Merci de saisir une adresse e-mail valide.";
+    }
+
+    if (!trimmedFirstName) {
+      errors.firstName = 'Le prénom est requis pour personnaliser nos messages.';
+    }
+
+    if (!formData.consent) {
+      errors.consent = "Nous avons besoin de votre consentement pour vous envoyer des actualités.";
+    }
+
+    return errors;
+  };
+
+  const hasErrors = useMemo(() => Object.keys(formErrors).length > 0, [formErrors]);
+
+  const handleChange = (field: keyof NewsletterFormData) =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const value = field === 'consent' ? event.target.checked : event.target.value;
+      setFormData((previous) => ({ ...previous, [field]: value }));
+
+      if (formErrors[field]) {
+        setFormErrors((previous) => ({ ...previous, [field]: undefined }));
+      }
+    };
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault();
+
+    const errors = validate();
+    setFormErrors(errors);
+
+    if (Object.keys(errors).length > 0) {
+      setStatus('error');
+      setSubmissionError('Veuillez vérifier les informations fournies.');
+      return;
+    }
+
+    setStatus('loading');
+    setSubmissionError(null);
+
+    try {
+      const { error } = await client.insert({
+        email: formData.email.trim().toLowerCase(),
+        first_name: formData.firstName.trim(),
+        consent: formData.consent,
+        subscribed_at: new Date().toISOString(),
+      });
+
+      if (error) {
+        throw error;
+      }
+
+      setStatus('success');
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Une erreur inattendue est survenue. Merci d'essayer à nouveau.";
+
+      setStatus('error');
+      setSubmissionError(
+        message ||
+          "Impossible d'enregistrer votre inscription pour le moment. Vérifiez votre connexion et réessayez.",
+      );
+    }
+  };
+
+  return (
+    <form className="newsletter" onSubmit={handleSubmit} noValidate>
+      <div className="newsletter__row">
+        <label className="newsletter__label" htmlFor="newsletter-email">
+          Adresse e-mail
+        </label>
+        <input
+          id="newsletter-email"
+          name="email"
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          placeholder="prenom@email.com"
+          className="newsletter__input"
+          value={formData.email}
+          onChange={handleChange('email')}
+          disabled={isLoading || status === 'success'}
+          aria-invalid={Boolean(formErrors.email)}
+          aria-describedby={formErrors.email ? 'newsletter-email-error' : undefined}
+          required
+        />
+        {formErrors.email ? (
+          <p id="newsletter-email-error" className="newsletter__error" role="alert">
+            {formErrors.email}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="newsletter__row">
+        <label className="newsletter__label" htmlFor="newsletter-first-name">
+          Prénom
+        </label>
+        <input
+          id="newsletter-first-name"
+          name="firstName"
+          type="text"
+          autoComplete="given-name"
+          placeholder="Camille"
+          className="newsletter__input"
+          value={formData.firstName}
+          onChange={handleChange('firstName')}
+          disabled={isLoading || status === 'success'}
+          aria-invalid={Boolean(formErrors.firstName)}
+          aria-describedby={formErrors.firstName ? 'newsletter-first-name-error' : undefined}
+          required
+        />
+        {formErrors.firstName ? (
+          <p id="newsletter-first-name-error" className="newsletter__error" role="alert">
+            {formErrors.firstName}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="newsletter__checkbox">
+        <input
+          id="newsletter-consent"
+          name="consent"
+          type="checkbox"
+          checked={formData.consent}
+          onChange={handleChange('consent')}
+          disabled={isLoading || status === 'success'}
+          aria-invalid={Boolean(formErrors.consent)}
+          aria-describedby={formErrors.consent ? 'newsletter-consent-error' : undefined}
+          required
+        />
+        <label htmlFor="newsletter-consent">
+          J'accepte de recevoir les communications marketing de Jocelyne K et je confirme avoir pris
+          connaissance de la politique de confidentialité.
+        </label>
+      </div>
+      {formErrors.consent ? (
+        <p id="newsletter-consent-error" className="newsletter__error" role="alert">
+          {formErrors.consent}
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        className="newsletter__submit"
+        disabled={isLoading || status === 'success'}
+        aria-live="polite"
+        aria-busy={isLoading}
+      >
+        {isLoading ? (
+          <span className="newsletter__spinner" aria-hidden>
+            <svg viewBox="0 0 24 24" role="presentation">
+              <circle className="newsletter__spinner-track" cx="12" cy="12" r="10" />
+              <circle className="newsletter__spinner-indicator" cx="12" cy="12" r="10" />
+            </svg>
+            Envoi en cours...
+          </span>
+        ) : status === 'success' ? (
+          'Inscription confirmée !'
+        ) : (
+          "S'inscrire"
+        )}
+      </button>
+
+      <div className="newsletter__feedback" aria-live="polite">
+        {status === 'success' ? (
+          <p className="newsletter__success">
+            Merci ! Votre adresse est ajoutée à notre liste sécurisée. Vous recevrez bientôt un e-mail de
+            bienvenue avec un code exclusif.
+          </p>
+        ) : null}
+        {status === 'error' && submissionError && !hasErrors ? (
+          <p className="newsletter__error" role="alert">
+            {submissionError}
+          </p>
+        ) : null}
+      </div>
+
+      {status === 'success' ? (
+        <button type="button" className="newsletter__reset" onClick={resetForm}>
+          Ajouter une autre personne
+        </button>
+      ) : null}
+    </form>
+  );
+};
+
+export default NewsletterForm;
+
+export type { NewsletterClient, NewsletterFormProps };

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,358 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top right, #fde68a, #f8fafc 40%);
+}
+
+a {
+  color: inherit;
+}
+
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.hero {
+  display: grid;
+  gap: 3rem;
+  padding: 4rem clamp(1.5rem, 4vw, 5rem) 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.85rem;
+  color: #f97316;
+  font-weight: 600;
+}
+
+.hero__title {
+  margin: 0;
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  line-height: 1.05;
+  font-weight: 700;
+}
+
+.hero__subtitle {
+  margin: 0;
+  color: #334155;
+  max-width: 540px;
+  font-size: 1.05rem;
+}
+
+.hero__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  padding: 0.85rem 1.75rem;
+  background: #0f172a;
+  color: #f8fafc;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero__cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px -12px rgba(15, 23, 42, 0.6);
+}
+
+.hero__visual {
+  position: relative;
+  min-height: 280px;
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.18), rgba(244, 114, 182, 0.25));
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+}
+
+.hero__badge {
+  position: absolute;
+  top: 1.5rem;
+  right: 1.5rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+}
+
+main {
+  flex: 1;
+}
+
+.cta {
+  padding: 0 1.5rem 5rem;
+}
+
+.cta__content {
+  margin: 0 auto;
+  max-width: 720px;
+  background: #ffffff;
+  border-radius: 24px;
+  padding: clamp(2rem, 5vw, 3rem);
+  box-shadow: 0 32px 80px -40px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cta__title {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  line-height: 1.2;
+}
+
+.cta__description {
+  margin: 0;
+  color: #475569;
+}
+
+.cta__security {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #1e293b;
+  background: linear-gradient(90deg, rgba(14, 165, 233, 0.12), rgba(244, 114, 182, 0.12));
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+}
+
+.footer {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 3rem 1.5rem;
+}
+
+.footer__content {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.footer__title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.footer__text {
+  margin: 0;
+  color: #cbd5f5;
+  max-width: 520px;
+}
+
+.footer__security-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.footer__security-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #cbd5f5;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.footer__legal {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #94a3b8;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding-top: 3rem;
+  }
+
+  .hero__visual {
+    min-height: 220px;
+  }
+}
+
+.newsletter {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.newsletter__row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.newsletter__label {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.newsletter__input {
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.newsletter__input:focus {
+  outline: none;
+  border-color: rgba(14, 165, 233, 0.6);
+  box-shadow: 0 0 0 3px rgba(14, 165, 233, 0.25);
+}
+
+.newsletter__input:disabled {
+  background: rgba(226, 232, 240, 0.35);
+  cursor: not-allowed;
+}
+
+.newsletter__checkbox {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: flex-start;
+  font-size: 0.95rem;
+  color: #334155;
+}
+
+.newsletter__checkbox input[type='checkbox'] {
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-top: 0.25rem;
+}
+
+.newsletter__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.95rem 1.75rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  color: #f8fafc;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.newsletter__submit:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.newsletter__submit:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 30px -18px rgba(15, 23, 42, 0.75);
+}
+
+.newsletter__spinner {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.newsletter__spinner svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.newsletter__spinner-track {
+  fill: none;
+  stroke: rgba(255, 255, 255, 0.2);
+  stroke-width: 4;
+}
+
+.newsletter__spinner-indicator {
+  fill: none;
+  stroke: #f8fafc;
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-dasharray: 60;
+  stroke-dashoffset: 60;
+  animation: spinner 1.2s ease-in-out infinite;
+}
+
+@keyframes spinner {
+  0% {
+    stroke-dashoffset: 60;
+  }
+  50% {
+    stroke-dashoffset: 15;
+  }
+  100% {
+    stroke-dashoffset: 60;
+  }
+}
+
+.newsletter__error {
+  color: #ef4444;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.newsletter__success {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(34, 197, 94, 0.12);
+  color: #166534;
+  font-weight: 500;
+}
+
+.newsletter__feedback {
+  min-height: 1.5rem;
+}
+
+.newsletter__reset {
+  justify-self: start;
+  padding: 0.65rem 1.25rem;
+  border-radius: 10px;
+  border: 1px solid rgba(15, 23, 42, 0.2);
+  background: transparent;
+  cursor: pointer;
+  font-weight: 500;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.newsletter__reset:hover {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+@media (max-width: 600px) {
+  .newsletter__checkbox {
+    grid-template-columns: 1fr;
+  }
+
+  .newsletter__checkbox input[type='checkbox'] {
+    margin-top: 0;
+  }
+}

--- a/src/lib/mocks/supabaseClientMock.ts
+++ b/src/lib/mocks/supabaseClientMock.ts
@@ -1,0 +1,39 @@
+import type { PostgrestError } from '@supabase/supabase-js';
+
+type InsertPayload = Record<string, unknown>;
+
+type MockOptions = {
+  delayMs?: number;
+  error?: Partial<PostgrestError> & { message: string };
+};
+
+const wait = (duration: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, duration);
+  });
+
+export const createSupabaseNewsletterMock = ({ delayMs = 0, error }: MockOptions = {}) => {
+  return {
+    async insert(payload: InsertPayload) {
+      void payload;
+      if (delayMs > 0) {
+        await wait(delayMs);
+      }
+
+      if (error) {
+        return {
+          error: {
+            code: error.code ?? 'MOCK_ERROR',
+            details: error.details ?? 'Erreur simulée pour test manuel.',
+            hint: error.hint ?? null,
+            message: error.message,
+          } satisfies PostgrestError,
+        };
+      }
+
+      return { error: null };
+    },
+  };
+};
+
+export type SupabaseNewsletterMock = ReturnType<typeof createSupabaseNewsletterMock>;

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('VITE_SUPABASE_URL est requis pour initialiser Supabase.');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('VITE_SUPABASE_ANON_KEY est requis pour initialiser Supabase.');
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    persistSession: false,
+  },
+});
+
+export type SupabaseClientInstance = typeof supabase;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## Summary
- initialize a Supabase client based on Vite environment variables
- implement a newsletter subscription form with client-side validation, loading states, and Supabase persistence
- add a landing page layout featuring the CTA, GDPR-compliant messaging, and supporting styles plus a mock client for manual testing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d07daad790832c90b9246ff3bb0ec2