### PR TITLE
Add testimonials carousel and service highlights

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,175 @@
+import { ArrowUpRight, Sparkles } from 'lucide-react';
+import PressAndPartners from './components/PressAndPartners';
+import ServiceHighlights from './components/ServiceHighlights';
+import Testimonials from './components/Testimonials';
+
+const products = [
+  {
+    name: 'Monture Riviera 70’s',
+    description: 'Acétate translucide champagne et verres ambrés anti-reflets.',
+    price: '249 €',
+    image:
+      'https://images.unsplash.com/photo-1511499767150-a48a237f0083?auto=format&fit=crop&w=900&q=80',
+  },
+  {
+    name: 'Lunettes Solaris Bold',
+    description: 'Monture oversized ébène avec branches martelées et verres dégradés.',
+    price: '279 €',
+    image:
+      'https://images.unsplash.com/photo-1527698266440-12104e498b76?auto=format&fit=crop&w=900&q=80',
+  },
+  {
+    name: 'Modèle Atelier 03',
+    description: 'Ligne unisexe à pont keyhole, finitions dorées et verres polarisés.',
+    price: '305 €',
+    image:
+      'https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=900&q=80',
+  },
+];
+
+const App = () => {
+  return (
+    <div className="min-h-screen bg-white font-sans text-slate-900">
+      <header className="overflow-hidden bg-gradient-to-br from-amber-100/60 via-white to-white">
+        <div className="mx-auto flex max-w-6xl flex-col items-start gap-16 px-4 py-24 sm:px-6 lg:flex-row lg:items-center lg:px-8">
+          <div className="flex-1">
+            <span className="inline-flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.45em] text-amber-600">
+              <Sparkles className="h-3.5 w-3.5" />
+              Nouvelle collection
+            </span>
+            <h1 className="mt-6 text-4xl font-semibold leading-tight sm:text-5xl lg:text-6xl">
+              Solaires d’exception façonnées dans notre atelier lyonnais
+            </h1>
+            <p className="mt-6 max-w-xl text-lg text-slate-600">
+              Les créations Jocelyne K combinent matériaux responsables, lignes audacieuses et confort absolu. Chaque monture est
+              imaginée pour sublimer les personnalités solaires.
+            </p>
+            <div className="mt-8 flex flex-wrap items-center gap-4">
+              <a
+                href="#produits"
+                className="inline-flex items-center gap-2 rounded-full bg-amber-500 px-6 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-white shadow-lg transition hover:bg-amber-400"
+              >
+                Voir les modèles
+                <ArrowUpRight className="h-4 w-4" />
+              </a>
+              <span className="text-sm uppercase tracking-[0.35em] text-slate-400">Garantie atelier 2 ans</span>
+            </div>
+          </div>
+
+          <div className="relative flex-1 self-stretch lg:h-[520px]">
+            <div className="absolute inset-0 rounded-[3rem] bg-gradient-to-br from-amber-200/50 via-amber-100 to-white blur-3xl" />
+            <div className="relative h-full overflow-hidden rounded-[3rem] border border-amber-200/60 bg-white shadow-[0_60px_120px_-70px_rgba(217,119,6,0.9)]">
+              <img
+                src="https://images.unsplash.com/photo-1490474418585-ba9bad8fd0ea?auto=format&fit=crop&w=1200&q=80"
+                alt="Collection Jocelyne K"
+                className="h-full w-full object-cover"
+                loading="lazy"
+              />
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main>
+        <section id="produits" className="py-20">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <span className="text-sm font-semibold uppercase tracking-[0.45em] text-amber-500">Modèles iconiques</span>
+                <h2 className="mt-3 text-3xl font-semibold sm:text-4xl">Des lignes sculptées pour capter la lumière</h2>
+              </div>
+              <p className="max-w-xl text-sm text-slate-500 sm:text-base">
+                Une sélection limitée produite en séries numérotées. Nos lunettes sont assemblées à la main et contrôlées
+                minutieusement avant expédition.
+              </p>
+            </div>
+
+            <div className="mt-12 grid gap-8 md:grid-cols-3">
+              {products.map((product) => (
+                <article
+                  key={product.name}
+                  className="group overflow-hidden rounded-[2.5rem] border border-amber-100 bg-white shadow-[0_40px_90px_-60px_rgba(15,23,42,0.5)] transition hover:-translate-y-2 hover:border-amber-300/70"
+                >
+                  <div className="relative h-72 overflow-hidden">
+                    <img
+                      src={product.image}
+                      alt={product.name}
+                      className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+                      loading="lazy"
+                    />
+                    <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black/70 via-black/0 to-transparent" />
+                    <span className="absolute left-6 top-6 inline-flex items-center rounded-full bg-white/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.45em] text-slate-700 shadow">
+                      Atelier
+                    </span>
+                  </div>
+                  <div className="space-y-3 px-6 pb-8 pt-6">
+                    <h3 className="text-xl font-semibold text-slate-900">{product.name}</h3>
+                    <p className="text-sm text-slate-500 sm:text-base">{product.description}</p>
+                    <div className="flex items-center justify-between">
+                      <span className="text-lg font-semibold text-amber-600">{product.price}</span>
+                      <a
+                        href="#cta"
+                        className="inline-flex items-center gap-2 rounded-full border border-amber-200 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-amber-600 transition hover:border-amber-400 hover:bg-amber-50"
+                      >
+                        Réserver
+                        <ArrowUpRight className="h-4 w-4" />
+                      </a>
+                    </div>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <Testimonials />
+        <PressAndPartners />
+        <ServiceHighlights />
+
+        <section id="cta" className="py-24">
+          <div className="mx-auto max-w-4xl rounded-[3rem] bg-gradient-to-r from-amber-500 to-amber-400 px-8 py-16 text-center text-white shadow-[0_60px_120px_-40px_rgba(217,119,6,0.7)]">
+            <h2 className="text-3xl font-semibold sm:text-4xl">Prêt·e à révéler votre aura solaire ?</h2>
+            <p className="mx-auto mt-4 max-w-2xl text-base sm:text-lg">
+              Prenez rendez-vous pour un essayage privé en visio ou à l’atelier Jocelyne K. Nos stylistes vous accompagnent pour
+              trouver la monture qui vous ressemble.
+            </p>
+            <div className="mt-8 flex flex-wrap justify-center gap-4">
+              <a
+                href="mailto:bonjour@jocelynek.com"
+                className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-amber-600 transition hover:bg-amber-50"
+              >
+                Réserver un rendez-vous
+                <ArrowUpRight className="h-4 w-4" />
+              </a>
+              <a
+                href="#testimonials"
+                className="inline-flex items-center gap-2 rounded-full border border-white/60 px-6 py-3 text-sm font-semibold uppercase tracking-[0.4em] text-white transition hover:bg-white/10"
+              >
+                Découvrir les avis
+              </a>
+            </div>
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t border-slate-200 py-8">
+        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 text-sm text-slate-500 sm:flex-row sm:px-6 lg:px-8">
+          <span>© {new Date().getFullYear()} Jocelyne K — Atelier lunetier français</span>
+          <div className="flex items-center gap-4 uppercase tracking-[0.35em]">
+            <a href="#produits" className="hover:text-amber-500">
+              Collection
+            </a>
+            <a href="#services" className="hover:text-amber-500">
+              Services
+            </a>
+            <a href="mailto:bonjour@jocelynek.com" className="hover:text-amber-500">
+              Contact
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/PressAndPartners.tsx
+++ b/src/components/PressAndPartners.tsx
@@ -1,0 +1,43 @@
+const pressMentions = [
+  { name: 'Le Bon Look', tagline: 'Sélection coup de cœur' },
+  { name: 'Madame Mode', tagline: 'Accessoires premium' },
+  { name: 'Lunettes & Co', tagline: 'Innovation optique' },
+  { name: 'Style.fr', tagline: 'Tendance été 2024' },
+  { name: 'La Tribune', tagline: 'Savoir-faire français' },
+  { name: 'Voyageurs', tagline: 'Indispensable en city-break' },
+];
+
+const PressAndPartners = () => (
+  <section aria-labelledby="press-title" className="bg-white py-14">
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div className="text-center">
+        <p className="text-xs font-semibold uppercase tracking-[0.5em] text-slate-400">Ils parlent de nous</p>
+        <h2 id="press-title" className="mt-3 text-2xl font-semibold text-slate-900 sm:text-3xl">
+          Presse & partenaires de confiance
+        </h2>
+        <p className="mx-auto mt-2 max-w-2xl text-sm text-slate-500 sm:text-base">
+          De la presse lifestyle aux magazines spécialisés, la collection Jocelyne K séduit par son esthétique audacieuse et sa
+          fabrication artisanale.
+        </p>
+      </div>
+
+      <div className="mt-10 grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
+        {pressMentions.map((mention) => (
+          <div
+            key={mention.name}
+            className="flex h-28 flex-col items-center justify-center rounded-2xl border border-slate-100 bg-slate-50/40 text-center transition hover:border-amber-200 hover:bg-amber-50/60"
+          >
+            <span className="text-lg font-semibold uppercase tracking-[0.35em] text-slate-400 filter grayscale">
+              {mention.name}
+            </span>
+            <span className="mt-2 text-xs uppercase tracking-[0.4em] text-slate-300">
+              {mention.tagline}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </section>
+);
+
+export default PressAndPartners;

--- a/src/components/ServiceHighlights.tsx
+++ b/src/components/ServiceHighlights.tsx
@@ -1,0 +1,58 @@
+import type { LucideIcon } from 'lucide-react';
+import { Palette, RefreshCcw, Truck } from 'lucide-react';
+
+const services: Array<{ title: string; description: string; icon: LucideIcon }> = [
+  {
+    title: 'Livraison express & soignée',
+    description:
+      'Expédition en 48h partout en France métropolitaine, avec un écrin recyclé et des accessoires de soin inclus.',
+    icon: Truck,
+  },
+  {
+    title: 'Retours gratuits 30 jours',
+    description:
+      'Essayez vos lunettes en toute tranquillité : ajustements offerts et échanges facilités directement depuis votre espace client.',
+    icon: RefreshCcw,
+  },
+  {
+    title: 'Personnalisation signature',
+    description:
+      'Gravure des initiales, verres teintés sur mesure et ajustage à la morphologie réalisés par nos artisans lunetiers.',
+    icon: Palette,
+  },
+];
+
+const ServiceHighlights = () => (
+  <section id="services" className="bg-slate-900 py-20 text-white">
+    <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+      <div className="max-w-2xl">
+        <span className="text-sm font-semibold uppercase tracking-[0.4em] text-amber-400">Services signature</span>
+        <h2 className="mt-4 text-3xl font-semibold sm:text-4xl">Une expérience haut de gamme du clic à la rue</h2>
+        <p className="mt-3 text-base text-slate-300 sm:text-lg">
+          Notre équipe suit chaque commande de la sélection à l’entretien. Profitez d’un accompagnement personnalisé avant et
+          après votre achat.
+        </p>
+      </div>
+
+      <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {services.map((service) => {
+          const Icon = service.icon;
+          return (
+            <article
+              key={service.title}
+              className="group flex flex-col gap-4 rounded-3xl border border-slate-700/60 bg-slate-800/60 p-8 shadow-[0_40px_80px_-40px_rgba(15,23,42,0.8)] transition hover:-translate-y-1 hover:border-amber-400/80 hover:bg-slate-800/80"
+            >
+              <span className="flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-500/10 text-amber-300 transition group-hover:bg-amber-400/20 group-hover:text-amber-200">
+                <Icon className="h-7 w-7" />
+              </span>
+              <h3 className="text-xl font-semibold">{service.title}</h3>
+              <p className="text-sm leading-relaxed text-slate-300 sm:text-base">{service.description}</p>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+);
+
+export default ServiceHighlights;

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef } from 'react';
+import { ArrowLeft, ArrowRight, Quote, Star } from 'lucide-react';
+
+const testimonials = [
+  {
+    name: 'Camille R.',
+    role: 'Créatrice de contenu',
+    rating: 5,
+    quote:
+      'Des montures incroyablement légères avec un style rétro que je n’ai trouvé nulle part ailleurs. Je me sens unique à chaque sortie.',
+    image:
+      'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=200&q=80',
+  },
+  {
+    name: 'Yacine B.',
+    role: 'Entrepreneur',
+    rating: 4,
+    quote:
+      'La personnalisation a été rapide et précise. On voit vraiment la différence avec une approche artisanale et sur-mesure.',
+    image:
+      'https://images.unsplash.com/photo-1522556189639-b15089575906?auto=format&fit=crop&w=200&q=80',
+  },
+  {
+    name: 'Inès L.',
+    role: 'Styliste freelance',
+    rating: 5,
+    quote:
+      'Livraison express, emballage soigné et surtout des verres qui protègent parfaitement mes yeux sensibles. Une révélation !',
+    image:
+      'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=200&q=80',
+  },
+  {
+    name: 'Mathis D.',
+    role: 'Consultant',
+    rating: 5,
+    quote:
+      'Je reçois des compliments à chaque réunion. Les matériaux sont premium et la tenue est impeccable toute la journée.',
+    image:
+      'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=200&q=80',
+  },
+];
+
+const Testimonials = () => {
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const track = trackRef.current;
+    if (!track) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      const maxScrollLeft = track.scrollWidth - track.clientWidth;
+      if (track.scrollLeft >= maxScrollLeft - 16) {
+        track.scrollTo({ left: 0, behavior: 'smooth' });
+        return;
+      }
+
+      track.scrollBy({ left: track.clientWidth * 0.9, behavior: 'smooth' });
+    }, 6000);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const scroll = (direction: 'prev' | 'next') => {
+    const track = trackRef.current;
+    if (!track) {
+      return;
+    }
+
+    const offset = track.clientWidth * 0.9;
+    track.scrollBy({
+      left: direction === 'next' ? offset : -offset,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <section id="testimonials" className="bg-gradient-to-b from-white via-amber-50 to-white py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+          <div className="max-w-2xl">
+            <span className="text-sm font-semibold uppercase tracking-[0.3em] text-amber-500">
+              Avis clients
+            </span>
+            <h2 className="mt-3 text-3xl font-bold text-slate-900 sm:text-4xl">
+              Une communauté conquise par l’élégance artisanale
+            </h2>
+            <p className="mt-3 text-base text-slate-600 sm:text-lg">
+              Chaque paire est façonnée à la main dans notre atelier lyonnais. Découvrez les impressions de celles et ceux
+              qui portent déjà nos solaires signature.
+            </p>
+          </div>
+          <div className="flex gap-2 self-end md:self-auto">
+            <button
+              type="button"
+              onClick={() => scroll('prev')}
+              className="flex h-11 w-11 items-center justify-center rounded-full border border-amber-200 bg-white text-amber-600 transition hover:border-amber-400 hover:text-amber-700"
+              aria-label="Voir le témoignage précédent"
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </button>
+            <button
+              type="button"
+              onClick={() => scroll('next')}
+              className="flex h-11 w-11 items-center justify-center rounded-full border border-amber-200 bg-white text-amber-600 transition hover:border-amber-400 hover:text-amber-700"
+              aria-label="Voir le témoignage suivant"
+            >
+              <ArrowRight className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+
+        <div className="relative mt-10">
+          <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-amber-50 via-amber-50 to-transparent" />
+          <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-amber-50 via-amber-50 to-transparent" />
+
+          <div
+            ref={trackRef}
+            className="flex snap-x snap-mandatory gap-6 overflow-x-auto pb-6 pr-6 scrollbar-thin scrollbar-track-transparent scrollbar-thumb-amber-200/60 sm:pr-0 [&::-webkit-scrollbar]:hidden"
+          >
+            {testimonials.map((testimonial) => (
+              <article
+                key={testimonial.name}
+                className="relative flex min-w-[85%] max-w-sm flex-col justify-between rounded-3xl border border-amber-100 bg-white/80 p-7 shadow-[0_30px_60px_-30px_rgba(217,119,6,0.45)] backdrop-blur sm:min-w-[360px]"
+              >
+                <Quote className="absolute -top-5 right-6 h-10 w-10 rounded-full bg-amber-500/10 p-2 text-amber-500" />
+                <div>
+                  <div className="flex items-center gap-3">
+                    <img
+                      src={testimonial.image}
+                      alt={testimonial.name}
+                      className="h-14 w-14 rounded-full border-4 border-white object-cover shadow-md"
+                      loading="lazy"
+                    />
+                    <div>
+                      <p className="text-lg font-semibold text-slate-900">{testimonial.name}</p>
+                      <p className="text-sm text-slate-500">{testimonial.role}</p>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 flex items-center gap-1">
+                    {Array.from({ length: 5 }).map((_, index) => (
+                      <Star
+                        key={index}
+                        className={`h-4 w-4 ${index < testimonial.rating ? 'fill-amber-400 text-amber-400' : 'text-amber-200'}`}
+                      />
+                    ))}
+                    <span className="ml-2 text-sm font-medium text-amber-600">{testimonial.rating}.0</span>
+                  </div>
+
+                  <p className="mt-5 text-base text-slate-600">“{testimonial.quote}”</p>
+                </div>
+
+                <div className="mt-6 flex items-center gap-3 text-xs uppercase tracking-[0.35em] text-amber-400">
+                  <span className="inline-flex h-2 w-2 rounded-full bg-amber-400" />
+                  Client vérifié
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Testimonials;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-white text-slate-900 antialiased;
+}
+
+a {
+  @apply text-inherit no-underline;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## Summary
- create dedicated components for testimonials, press mentions and service highlights
- build App layout with hero, products, social proof and CTA sections
- add main entry point and Tailwind base styles for the landing page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d07da55c60832c8901cb43f752746c