### PR TITLE
Add luxury Tailwind theme and premium layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# jocelynek
+# Boutique Jocelyne K – Landing page Vite + React + Tailwind CSS
+
+Cette version du projet met l&apos;accent sur une direction artistique premium (doré/sable/noir) avec des espacements adaptés aux sections et une typographie haut de gamme.
+
+## Palette & thèmes Tailwind
+
+Le fichier [`tailwind.config.js`](./tailwind.config.js) étend `theme.extend` avec :
+
+- Une palette complète `gold`, `sand` et `charcoal` pour couvrir les besoins de contraste (CTA, fonds de cartes, textes).
+- Des familles de polices premium (`fontFamily.sans = "Manrope"`, `fontFamily.display/signature = "Cormorant Garamond"`).
+- Des espacements dédiés aux sections (`py-section`, `py-section-sm`, `py-section-lg`) pour garantir une respiration cohérente entre les blocs.
+- Deux dégradés réutilisables (`bg-luxury-linear`, `bg-luxury-radial`) pour enrichir les arrière-plans.
+
+## Styles globaux & classes clés
+
+La feuille [`src/styles/global.css`](./src/styles/global.css) importe Tailwind et ajoute les styles suivants pour assurer la cohérence visuelle :
+
+| Classe utilitaire | Rôle principal |
+| --- | --- |
+| `.container-premium` | Largeur de lecture contrôlée avec marges latérales adaptées (`max-w-6xl`). |
+| `.section-shell` | Bloc principal des sections : fond translucide, bordure sable, `p-section` et `backdrop-blur` pour l&apos;effet verrier. |
+| `.btn-primary` | CTA doré avec gradient, états `hover`/`focus-visible`, variations `md:`/`lg:` sur le padding et la typo. |
+| `.btn-secondary` | Bouton secondaire en verre dépoli (bordure charbon, hover doré, focus contrasté). |
+| `.card-luxe` + `.card-accent` | Carte produit/expérience avec effets `hover`/`focus-within` et accent lumineux. |
+| `.badge-premium`, `.eyebrow` | Hiérarchie textuelle (accroches / badges). |
+| `.shadow-luxe`, `.shadow-luxe-strong`, `.shadow-amber` | Ombres personnalisées pour CTA et cartes. |
+| `.text-gradient-luxe` | Titre avec gradient doré. |
+| `.bg-noise` | Texture subtile ajoutée sur certaines sections.
+
+## Structure des composants
+
+- `Hero` : présente la collection avec CTA primaire et secondaire (`hover`/`focus` + responsive `sm`/`md`/`lg`).
+- `ProductShowcase` : grilles de cartes produits (`card-luxe`, boutons `btn-primary`/`btn-secondary`).
+- `Experience` : détails des services premium avec boutons secondaires responsive.
+- `CallToAction` : formulaire d&apos;inscription au club privé (CTA primaire + input stylisé).
+- `Footer` : liens récurrents avec survol doré.
+
+L&apos;entrée [`src/main.tsx`](./src/main.tsx) importe `src/styles/global.css` afin que toutes les pages bénéficient de ces styles dès le rendu initial.
+
+## Lancer le projet
+
+```bash
+npm install
+npm run dev
+```
+
+Le serveur de développement Vite est accessible sur `http://localhost:5173`.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,39 @@
+import Hero from './components/Hero';
+import ProductShowcase from './components/ProductShowcase';
+import Experience from './components/Experience';
+import CallToAction from './components/CallToAction';
+import Footer from './components/Footer';
+
+const App = () => (
+  <div className="min-h-screen bg-luxury-linear">
+    <header className="py-6">
+      <div className="container-premium flex flex-wrap items-center justify-between gap-4 rounded-full border border-white/60 bg-white/70 px-6 py-4 backdrop-blur">
+        <a href="#" className="font-display text-2xl text-charcoal-900">
+          Jocelyne K
+        </a>
+        <nav className="flex flex-wrap items-center gap-6 text-sm uppercase tracking-[0.4em] text-sand-700">
+          <a href="#collection" className="transition hover:text-gold-500 focus-visible:text-gold-500">
+            Collection
+          </a>
+          <a href="#experiences" className="transition hover:text-gold-500 focus-visible:text-gold-500">
+            Services
+          </a>
+          <a href="#cta" className="btn-secondary px-5 py-2 text-xs tracking-[0.3em]">
+            Club privé
+          </a>
+        </nav>
+      </div>
+    </header>
+
+    <main className="space-y-section">
+      <Hero />
+      <ProductShowcase />
+      <Experience />
+      <CallToAction />
+    </main>
+
+    <Footer />
+  </div>
+);
+
+export default App;

--- a/src/components/CallToAction.tsx
+++ b/src/components/CallToAction.tsx
@@ -1,0 +1,45 @@
+import { ArrowRight } from 'lucide-react';
+
+const CallToAction = () => (
+  <section id="cta" className="py-section-sm">
+    <div className="container-premium">
+      <div className="section-shell bg-gradient-to-r from-gold-100/80 via-gold-50/90 to-sand-100/80">
+        <div className="grid gap-8 md:grid-cols-[1.2fr,0.8fr] md:items-center">
+          <div className="space-y-4">
+            <span className="eyebrow text-charcoal-900">Club Lumière</span>
+            <h2 className="text-3xl text-charcoal-900 md:text-4xl lg:text-5xl">
+              Rejoignez le cercle privé Jocelyne K
+            </h2>
+            <p className="text-sand-900/80">
+              Invitations aux lancements exclusifs, accès aux précommandes et mise à disposition d&apos;une
+              concierge personnelle pour toutes vos envies solaires.
+            </p>
+          </div>
+
+          <form className="flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
+            <label className="sr-only" htmlFor="email">
+              Adresse e-mail
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              required
+              placeholder="Votre e-mail premium"
+              className="w-full rounded-full border border-sand-300 bg-white/90 px-6 py-3 text-sm text-charcoal-900 placeholder:text-sand-500 transition focus:border-gold-400 focus:ring-2 focus:ring-gold-200 md:flex-1 md:py-4"
+            />
+            <button
+              type="submit"
+              className="btn-primary inline-flex w-full justify-center gap-2 md:w-auto md:px-8 md:py-4"
+            >
+              Rejoindre
+              <ArrowRight className="h-4 w-4" />
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default CallToAction;

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,0 +1,69 @@
+import { Gem, HeartHandshake, Star } from 'lucide-react';
+
+const experiences = [
+  {
+    title: 'Essayage privé',
+    description:
+      'Un expert styliste vous accueille en salon ou en visioconseil pour sélectionner les montures adaptées à votre carnation et votre style de vie.',
+    icon: HeartHandshake,
+  },
+  {
+    title: 'Optique sur-mesure',
+    description:
+      'Verres dégradés, miroirs dorés, traitements anti-reflet et teintes personnalisées pour sublimer votre regard en toute saison.',
+    icon: Gem,
+  },
+  {
+    title: 'Programme Signature',
+    description:
+      'Gravage de vos initiales, livraison internationale premium et suivi d’entretien offert pendant deux ans.',
+    icon: Star,
+  },
+];
+
+const Experience = () => (
+  <section id="experiences" className="py-section-lg">
+    <div className="container-premium">
+      <div className="section-shell">
+        <div className="grid gap-14 lg:grid-cols-[0.75fr,1fr] lg:items-start">
+          <div className="space-y-6">
+            <span className="eyebrow">Expériences sur mesure</span>
+            <h2 className="text-4xl text-charcoal-900 md:text-5xl lg:text-6xl">
+              Un accompagnement premium au-delà du soleil
+            </h2>
+            <p className="text-lg text-sand-900/85">
+              La boutique Jocelyne K imagine un parcours d&apos;excellence pour chaque cliente : rendez-vous
+              privatisé, conseil en colorimétrie, signature olfactive et ateliers créatifs autour de la
+              lunetterie d&apos;art.
+            </p>
+            <a
+              href="#cta"
+              className="btn-secondary w-full justify-center hover:-translate-y-[3px] focus-visible:-translate-y-[3px] md:w-auto"
+            >
+              Réserver un moment privilégié
+            </a>
+          </div>
+
+          <div className="grid gap-8 md:grid-cols-2">
+            {experiences.map(({ title, description, icon: Icon }) => (
+              <article key={title} className="card-luxe group p-8 md:p-9">
+                <span className="card-accent" aria-hidden="true" />
+                <Icon className="h-10 w-10 text-gold-500" aria-hidden="true" />
+                <h3 className="text-2xl text-charcoal-900">{title}</h3>
+                <p className="text-sm text-sand-900/85 md:text-base">{description}</p>
+                <a
+                  href="#cta"
+                  className="btn-secondary mt-6 w-fit bg-white/60 px-5 py-2 text-xs uppercase hover:bg-gold-50/60 focus-visible:bg-gold-50/80"
+                >
+                  En savoir plus
+                </a>
+              </article>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default Experience;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,22 @@
+const Footer = () => (
+  <footer className="py-12">
+    <div className="container-premium flex flex-col gap-6 border-t border-sand-200/60 pt-10 text-sm text-sand-700 md:flex-row md:items-center md:justify-between">
+      <p>
+        © {new Date().getFullYear()} Jocelyne K. Lunettes de soleil de luxe façonnées en France.
+      </p>
+      <div className="flex gap-6">
+        <a href="#collection" className="transition hover:text-gold-500 focus-visible:text-gold-500">
+          Collection
+        </a>
+        <a href="#experiences" className="transition hover:text-gold-500 focus-visible:text-gold-500">
+          Expériences
+        </a>
+        <a href="#cta" className="transition hover:text-gold-500 focus-visible:text-gold-500">
+          Club privé
+        </a>
+      </div>
+    </div>
+  </footer>
+);
+
+export default Footer;

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,71 @@
+import { Sparkles, ArrowUpRight } from 'lucide-react';
+
+const Hero = () => (
+  <section className="py-section">
+    <div className="container-premium">
+      <div className="section-shell bg-noise">
+        <div className="flex flex-wrap items-center justify-between gap-6">
+          <span className="badge-premium">Signature Jocelyne K</span>
+          <div className="flex items-center gap-3 text-sm text-sand-700">
+            <Sparkles className="h-4 w-4 text-gold-500" />
+            Verres hautes performances & styles iconiques
+          </div>
+        </div>
+
+        <div className="mt-12 grid gap-12 md:grid-cols-[1.1fr,0.9fr] md:items-center">
+          <div className="space-y-8">
+            <div>
+              <span className="eyebrow">Collection Été 2024</span>
+              <h1 className="text-4xl leading-[1.1] text-gradient-luxe sm:text-5xl lg:text-6xl">
+                L&apos;élégance lumineuse pour vos instants les plus précieux
+              </h1>
+            </div>
+
+            <p className="max-w-xl text-lg text-sand-900/80">
+              Des montures façonnées main dans des matériaux nobles, des verres polarisés dorés
+              et une signature maison inspirée de la Côte d&apos;Azur. Découvrez une nouvelle idée du
+              luxe solaire.
+            </p>
+
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+              <a
+                href="#collection"
+                className="btn-primary hover:translate-y-[-2px] focus-visible:translate-y-[-2px]"
+              >
+                Explorer la collection
+                <ArrowUpRight className="ml-3 h-4 w-4" />
+              </a>
+              <a
+                href="#experiences"
+                className="btn-secondary hover:-translate-y-[2px] focus-visible:-translate-y-[2px]"
+              >
+                Prendre rendez-vous
+              </a>
+            </div>
+          </div>
+
+          <div className="relative flex items-center justify-center">
+            <div className="absolute inset-y-0 w-full rounded-full bg-gradient-to-br from-gold-100 via-sand-100 to-transparent blur-3xl" />
+            <div className="relative aspect-[3/4] w-4/5 overflow-hidden rounded-[3rem] border border-white/40 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.85),rgba(246,237,225,0.65))] shadow-luxe">
+              <div className="absolute inset-0 bg-[url('https://images.unsplash.com/photo-1511499767150-a48a237f0083?auto=format&fit=crop&w=900&q=80')] bg-cover bg-center mix-blend-luminosity" />
+              <div className="relative flex h-full flex-col justify-between p-8 text-white">
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.4em]">
+                  <span>Maison Riviera</span>
+                  <span>Depuis 1987</span>
+                </div>
+                <div className="text-right">
+                  <span className="font-display text-4xl leading-none">Azur Nocturne</span>
+                  <p className="mt-3 max-w-[12rem] text-sm text-white/80">
+                    Monture titane, verres miroir sable doux, finition or champagne 24K.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default Hero;

--- a/src/components/ProductShowcase.tsx
+++ b/src/components/ProductShowcase.tsx
@@ -1,0 +1,73 @@
+const products = [
+  {
+    name: 'Capri Solstice',
+    description:
+      'Acétate italien poli main, branches plaquées or rose 18K, verres dégradés sable lumineux.',
+    price: '420€',
+    badge: 'Édition limitée',
+  },
+  {
+    name: 'Monaco Horizon',
+    description:
+      'Monture titane ultra-légère, cerclage noir laqué, traitement antireflet premium double-face.',
+    price: '510€',
+    badge: 'Best-seller',
+  },
+  {
+    name: 'Saint-Tropez Dawn',
+    description:
+      'Forme papillon, placage palladium, dégradé rose doré, signature Jocelyne K gravée.',
+    price: '465€',
+    badge: 'Nouveauté',
+  },
+];
+
+const ProductShowcase = () => (
+  <section id="collection" className="py-section">
+    <div className="container-premium">
+      <div className="section-shell">
+        <div className="mx-auto max-w-3xl text-center">
+          <span className="eyebrow">Collection Maison</span>
+          <h2 className="text-4xl text-charcoal-900 md:text-5xl">Des pièces sculptées pour capter la lumière</h2>
+          <p className="mt-6 text-lg text-sand-900/80">
+            Chaque monture est assemblée par nos artisans lunetiers en France, en séries limitées. Des
+            détails dorés travaillés à la feuille et des finitions polies à la main garantissent un rendu
+            éclatant.
+          </p>
+        </div>
+
+        <div className="mt-16 grid gap-8 md:grid-cols-3">
+          {products.map((product) => (
+            <article key={product.name} className="card-luxe group focus-within:outline-none">
+              <span className="card-accent" aria-hidden="true" />
+              <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-sand-500">
+                <span>{product.badge}</span>
+                <span>{product.price}</span>
+              </div>
+              <div>
+                <h3 className="text-2xl font-semibold text-charcoal-900 md:text-3xl">{product.name}</h3>
+                <p className="mt-4 text-sm text-sand-800/90 md:text-base">{product.description}</p>
+              </div>
+              <div className="mt-auto flex items-center justify-between">
+                <a
+                  href="#cta"
+                  className="btn-secondary hover:bg-gold-50/60 focus-visible:bg-gold-50/80 focus-visible:text-gold-600"
+                >
+                  Détails
+                </a>
+                <button
+                  type="button"
+                  className="btn-primary px-6 py-2 text-xs uppercase hover:scale-[1.02] focus-visible:scale-[1.02] md:px-7"
+                >
+                  Ajouter au panier
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default ProductShowcase;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,90 @@
+@import url('https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600;700&family=Manrope:wght@300;400;500;600;700&display=swap');
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: light;
+  }
+
+  body {
+    @apply bg-sand-50 font-sans text-sand-900 antialiased;
+    background-image:
+      radial-gradient(circle at 20% 20%, rgba(217, 196, 160, 0.6), transparent 55%),
+      radial-gradient(circle at 80% 0%, rgba(230, 209, 180, 0.65), transparent 50%),
+      linear-gradient(135deg, rgba(20, 20, 20, 0.08) 0%, rgba(255, 255, 255, 0) 45%),
+      url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320" fill="none"><path d="M0 160L160 0L320 160L160 320L0 160Z" fill="rgba(255,255,255,0.05)"/></svg>');
+    background-size: 100%, 120%, 100%, 320px;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    @apply font-display text-charcoal-900 tracking-tight;
+  }
+
+  p {
+    @apply text-base leading-relaxed text-sand-900/90;
+  }
+}
+
+@layer components {
+  .container-premium {
+    @apply mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-12;
+  }
+
+  .section-shell {
+    @apply relative overflow-hidden rounded-[2.75rem] border border-sand-200/70 bg-white/80 p-section shadow-luxe backdrop-blur-md;
+  }
+
+  .btn-primary {
+    @apply inline-flex items-center justify-center rounded-full bg-gradient-to-r from-gold-500 via-gold-400 to-gold-300 px-8 py-3 text-sm font-semibold uppercase tracking-[0.2em] text-charcoal-900 transition-all duration-300 hover:from-gold-400 hover:via-gold-300 hover:to-gold-200 hover:shadow-amber focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gold-200 md:px-10 md:py-4 lg:text-base;
+  }
+
+  .btn-secondary {
+    @apply inline-flex items-center justify-center rounded-full border border-charcoal-900/30 bg-white/70 px-6 py-2 text-sm font-medium text-charcoal-900 transition duration-300 hover:border-gold-400 hover:text-gold-500 hover:shadow-amber focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-charcoal-800 md:px-8 md:py-3;
+  }
+
+  .card-luxe {
+    @apply relative flex h-full flex-col gap-6 overflow-hidden rounded-[2rem] border border-sand-200/60 bg-white/90 p-8 shadow-luxe transition duration-300 hover:-translate-y-1 hover:shadow-luxe-strong focus-within:-translate-y-1 focus-within:shadow-luxe-strong md:p-10;
+  }
+
+  .card-accent {
+    @apply absolute inset-0 -z-10 bg-gradient-to-br from-gold-200/40 via-transparent to-transparent opacity-0 transition-opacity duration-500 group-hover:opacity-100;
+  }
+
+  .badge-premium {
+    @apply inline-flex items-center gap-2 rounded-full border border-gold-200/70 bg-gold-50/90 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-charcoal-900;
+  }
+
+  .eyebrow {
+    @apply mb-4 inline-flex items-center gap-3 text-[0.75rem] font-semibold uppercase tracking-[0.5em] text-gold-500;
+  }
+}
+
+@layer utilities {
+  .shadow-luxe {
+    box-shadow: 0 25px 50px -20px rgba(17, 17, 17, 0.18);
+  }
+
+  .shadow-luxe-strong {
+    box-shadow: 0 40px 80px -30px rgba(17, 17, 17, 0.24);
+  }
+
+  .shadow-amber {
+    box-shadow: 0 20px 40px -25px rgba(198, 166, 100, 0.45);
+  }
+
+  .text-gradient-luxe {
+    background-image: linear-gradient(120deg, #f5e5c3 0%, #c6a664 50%, #b0894f 100%);
+    -webkit-background-clip: text;
+    color: transparent;
+  }
+
+  .bg-noise {
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400"><filter id="n" x="0" y="0"><feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="3" stitchTiles="stitch"/></filter><rect width="400" height="400" filter="url(%23n)" opacity="0.12"/></svg>');
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,54 @@
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        gold: {
+          50: '#fdf8ed',
+          100: '#f8ebd1',
+          200: '#f0d9a7',
+          300: '#e8c47b',
+          400: '#ddb25e',
+          500: '#c6a664',
+          600: '#a48844',
+          700: '#876d32',
+          800: '#6b5526',
+          900: '#4c3b18',
+        },
+        sand: {
+          50: '#faf6f0',
+          100: '#f3ece1',
+          200: '#e8dcc9',
+          300: '#d9c6a9',
+          400: '#c7ae88',
+          500: '#b69870',
+          600: '#957757',
+          700: '#745840',
+          800: '#554031',
+          900: '#372a20',
+        },
+        charcoal: {
+          700: '#3d3a37',
+          800: '#262421',
+          900: '#141312',
+        },
+      },
+      fontFamily: {
+        sans: ['"Manrope"', 'system-ui', 'sans-serif'],
+        display: ['"Cormorant Garamond"', 'serif'],
+        signature: ['"Cormorant Garamond"', 'serif'],
+      },
+      spacing: {
+        'section-sm': 'clamp(3.5rem, 4vw, 5rem)',
+        section: 'clamp(4.5rem, 6vw, 7.5rem)',
+        'section-lg': 'clamp(6rem, 8vw, 10rem)',
+      },
+      backgroundImage: {
+        'luxury-radial':
+          'radial-gradient(circle at 30% 20%, rgba(248, 235, 209, 0.7), transparent 55%)',
+        'luxury-linear': 'linear-gradient(135deg, rgba(20, 20, 20, 0.1) 0%, rgba(255, 255, 255, 0) 45%)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- extend Tailwind with a gold, sand, and charcoal palette plus premium fonts and section spacing utilities
- add global Tailwind stylesheet with gradients, texture, and reusable button/card classes
- build a luxury landing page layout with responsive hero, product, experience, and CTA sections using the new styles

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d07d9ef5c8832c86e278a9227a4429